### PR TITLE
Add element to desktop file keywords

### DIFF
--- a/chat.schildi.desktop.desktop
+++ b/chat.schildi.desktop.desktop
@@ -6,4 +6,4 @@ Exec=/app/bin/schildichat-desktop %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
 MimeType=x-scheme-handler/element;
 StartupWMClass=schildichat
-Keywords=Matrix;client;matrix.org;schildi.chat;schildi;chat;irc;communications;talk;
+Keywords=Matrix;client;matrix.org;schildi.chat;schildi;element;chat;irc;communications;talk;


### PR DESCRIPTION
Since schildichat is an element fork I think it's good ux for it to show up when searching for "element".

This is the same behavior as the gnome fractal 
https://gitlab.gnome.org/GNOME/fractal/-/blob/main/data/org.gnome.Fractal.desktop.in.in#L13