### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/chat.schildi.desktop.yaml
+++ b/chat.schildi.desktop.yaml
@@ -31,8 +31,6 @@ finish-args:
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Required for tray icons on KDE
-  - --own-name=org.kde.*
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver
   # Required for advanced input methods e.g. writing CJK languages


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 24.0.0
https://github.com/SchildiChat/element-desktop/blob/2f54ef60617db8b5d4a8acdb3ae90721d05de3b3/package.json#L91

See also https://github.com/flathub/im.riot.Riot/pull/386