### PR TITLE
Update base- and runtime-version in chat.schildi.desktop.yaml

### DIFF
--- a/chat.schildi.desktop.yaml
+++ b/chat.schildi.desktop.yaml
@@ -1,9 +1,9 @@
 ---
 app-id: chat.schildi.desktop
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: schildichat-desktop
 rename-icon: schildichat-desktop


### PR DESCRIPTION
update base-version and runtime-version to 24.08