### PR TITLE
SchildiChat Desktop is deprecated

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
See https://schildi.chat/legacy/desktop/ for details:

> DEPRECATION NOTICE: This version of SchildiChat Desktop/Web is no longer maintained, and it is recommended you look out for alternatives, such as [Element Desktop](https://element.io/download) or [SchildiChat Revenge](https://schildi.chat/revenge).
If you want to stick to it for now (e.g. until you deem [SchildiChat Revenge](https://schildi.chat/revenge) sufficient for your usecase), it is recommended to use the latest [GitHub pre-release](https://github.com/SchildiChat/schildichat-desktop/releases/tag/v1.11.109-sc.0.test.0), but expect missing features.